### PR TITLE
increase touch area if checkbox is smaller than 44pt

### DIFF
--- a/Classes/BEMCheckBox.h
+++ b/Classes/BEMCheckBox.h
@@ -118,6 +118,10 @@ typedef NS_ENUM(NSInteger, BEMAnimationType) {
  */
 @property (nonatomic) BEMAnimationType offAnimationType;
 
+/** If the checkbox width or height is smaller than this value, the touch area will be increased. Allows for visually small checkboxes to still be easily tapped. Default: (44, 44)
+ */
+@property (assign, nonatomic) IBInspectable CGSize minimumTouchSize;
+
 /** Set the state of the check box to On or Off, optionally animating the transition.
  */
 - (void)setOn:(BOOL)on animated:(BOOL)animated;

--- a/Classes/BEMCheckBox.m
+++ b/Classes/BEMCheckBox.m
@@ -173,6 +173,8 @@
     }
 }
 
+#pragma  mark - Helper methods -
+
 #pragma mark Increase touch area
 - (BOOL) pointInside:(CGPoint)point withEvent:(UIEvent *)event;
 {
@@ -194,7 +196,6 @@
     return found;
 }
 
-#pragma  mark - Helper methods -
 #pragma mark Drawings
 - (void)drawRect:(CGRect)rect {
     [self setOn:self.on animated:NO];

--- a/Classes/BEMCheckBox.m
+++ b/Classes/BEMCheckBox.m
@@ -59,6 +59,7 @@
     _tintColor = [UIColor lightGrayColor];
     _lineWidth = 2.0;
     _animationDuration = 0.5;
+    _minimumTouchSize = CGSizeMake(44, 44);
     _onAnimationType = BEMAnimationTypeStroke;
     _offAnimationType = BEMAnimationTypeStroke;
     self.backgroundColor = [UIColor clearColor];
@@ -172,20 +173,20 @@
     }
 }
 
-// increase touch area
+#pragma mark Increase touch area
 - (BOOL) pointInside:(CGPoint)point withEvent:(UIEvent *)event;
 {
     BOOL found = [super pointInside:point withEvent:event];
     
-    CGFloat minimumSize = 44;
-    CGFloat w = self.frame.size.width;
-    CGFloat h = self.frame.size.height;
+    CGSize minimumSize = self.minimumTouchSize;
+    CGFloat width = self.bounds.size.width;
+    CGFloat height = self.bounds.size.height;
     
-    if (found == NO && (w < minimumSize || h < minimumSize)) {
-        CGFloat increaseW = minimumSize - w;
-        CGFloat increaseH = minimumSize - h;
+    if (found == NO && (width < minimumSize.width || height < minimumSize.height)) {
+        CGFloat increaseWidth = minimumSize.width - width;
+        CGFloat increaseHeight = minimumSize.height - height;
         
-        CGRect rect = CGRectInset(self.bounds, (-increaseW/2), (-increaseH/2));
+        CGRect rect = CGRectInset(self.bounds, (-increaseWidth / 2), (-increaseHeight / 2));
         
         found = CGRectContainsPoint(rect, point);
     }

--- a/Classes/BEMCheckBox.m
+++ b/Classes/BEMCheckBox.m
@@ -172,6 +172,27 @@
     }
 }
 
+// increase touch area
+- (BOOL) pointInside:(CGPoint)point withEvent:(UIEvent *)event;
+{
+    BOOL found = [super pointInside:point withEvent:event];
+    
+    CGFloat minimumSize = 44;
+    CGFloat w = self.frame.size.width;
+    CGFloat h = self.frame.size.height;
+    
+    if (found == NO && (w < minimumSize || h < minimumSize)) {
+        CGFloat increaseW = minimumSize - w;
+        CGFloat increaseH = minimumSize - h;
+        
+        CGRect rect = CGRectInset(self.bounds, (-increaseW/2), (-increaseH/2));
+        
+        found = CGRectContainsPoint(rect, point);
+    }
+    
+    return found;
+}
+
 #pragma  mark - Helper methods -
 #pragma mark Drawings
 - (void)drawRect:(CGRect)rect {


### PR DESCRIPTION

If the checkbox is small, it can be difficult to tap. This PR increases the hit test area to a minimum of 44pt.