### PR TITLE
Fix for ObjectiveC++

### DIFF
--- a/Classes/BEMAnimationManager.h
+++ b/Classes/BEMAnimationManager.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2015 Boris Emorine. All rights reserved.
 //
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 
 /** Animation object used by BEMCheckBox to generate animations.
  */

--- a/Classes/BEMCheckBox.h
+++ b/Classes/BEMCheckBox.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2015 Boris Emorine. All rights reserved.
 //
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 
 @protocol BEMCheckBoxDelegate;
 

--- a/Classes/BEMPathManager.h
+++ b/Classes/BEMPathManager.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2015 Boris Emorine. All rights reserved.
 //
 
-@import UIKit;
+#import <UIKit/UIKit.h>
 #import "BEMCheckBox.h"
 
 /** Path object used by BEMCheckBox to generate paths.


### PR DESCRIPTION
In ObjectiveC++ (.mm files) we can't use modules.

http://stackoverflow.com/questions/32555710/xcode-modules-enabled-in-
settings-but-still-cant-use-import

Link to issue #27