### PR TITLE
Added support for target/action events

### DIFF
--- a/Classes/BEMCheckBox.h
+++ b/Classes/BEMCheckBox.h
@@ -32,9 +32,9 @@ NS_ASSUME_NONNULL_BEGIN
 /**  Tasteful Checkbox for iOS.
  */
 #if __IPHONE_OS_VERSION_MAX_ALLOWED > __IPHONE_9_3
-IB_DESIGNABLE @interface BEMCheckBox : UIView <CAAnimationDelegate>
+IB_DESIGNABLE @interface BEMCheckBox : UIControl <CAAnimationDelegate>
 #else
-IB_DESIGNABLE @interface BEMCheckBox : UIView
+IB_DESIGNABLE @interface BEMCheckBox : UIControl
 #endif
 
 /** The different type of animations available.

--- a/Classes/BEMCheckBox.m
+++ b/Classes/BEMCheckBox.m
@@ -171,6 +171,7 @@
     if ([self.delegate respondsToSelector:@selector(didTapCheckBox:)]) {
         [self.delegate didTapCheckBox:self];
     }
+    [self sendActionsForControlEvents:UIControlEventValueChanged];
 }
 
 #pragma  mark - Helper methods -


### PR DESCRIPTION
This PR adds support for UIControl's target/action events to be sent when the checkbox is toggled.

This matches UISwitch's behavior, and can make handling multiple checkboxes on the same screen a bit easier.

The change is very minor, and people using the existing delegate pattern won't be affected.