### PR TITLE
Added a new group feature for radio button functionality

### DIFF
--- a/Classes/BEMCheckBox.h
+++ b/Classes/BEMCheckBox.h
@@ -8,6 +8,7 @@
 
 #import <UIKit/UIKit.h>
 
+@class BEMCheckBoxGroup;
 @protocol BEMCheckBoxDelegate;
 
 /** The different type of boxes available.
@@ -107,6 +108,10 @@ typedef NS_ENUM(NSInteger, BEMAnimationType) {
 /** The color of the box when the checkbox is Off.
  */
 @property (strong, nonatomic) IBInspectable UIColor *tintColor;
+
+/** The group this box is associated with.
+ */
+@property (weak, nonatomic, nullable, readonly) BEMCheckBoxGroup *group;
 
 /** The type of box.
  * @see BEMBoxType. 

--- a/Classes/BEMCheckBox.m
+++ b/Classes/BEMCheckBox.m
@@ -132,7 +132,6 @@
         }
     }
     
-    // Notify our group if we have one that something has changed
     if(notifyGroup){
         [self.group _checkBoxSelectionChanged:self];
     }

--- a/Classes/BEMCheckBoxGroup.h
+++ b/Classes/BEMCheckBoxGroup.h
@@ -1,0 +1,39 @@
+//
+//  BEMCheckBoxGroup.h
+//  CheckBox
+//
+//  Created by Cory Imdieke on 10/17/16.
+//  Copyright © 2016 Boris Emorine. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@class BEMCheckBox;
+
+@interface BEMCheckBoxGroup : NSObject
+
+/** An array of check boxes in this group.
+ */
+@property (nonatomic, strong, nonnull, readonly) NSArray<BEMCheckBox *> *checkBoxes;
+
+/** The currently selected check box. Only can be nil if mustHaveSelection is NO. Setting this value will cause the other check boxes to deselect automatically.
+ */
+@property (nonatomic, strong, nullable) BEMCheckBox *selectedCheckBox;
+
+/** If YES, don't allow the user to unselect all options, must have single selection at all times. Default to NO.
+ */
+@property (nonatomic) BOOL mustHaveSelection;
+
+/** Creates a new group with the list of check boxes.
+ */
++ (nonnull instancetype)groupWithCheckBoxes:(nullable NSArray<BEMCheckBox *> *)checkBoxes;
+
+/** Adds a check box to this group. Check boxes can only belong to a single group, adding to a group removes it from its current group.
+ */
+- (void)addCheckBoxToGroup:(nonnull BEMCheckBox *)checkBox;
+
+/** Removes a check box from this group.
+ */
+- (void)removeCheckBoxFromGroup:(nonnull BEMCheckBox *)checkBox;
+
+@end

--- a/Classes/BEMCheckBoxGroup.h
+++ b/Classes/BEMCheckBoxGroup.h
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Boris Emorine. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 @class BEMCheckBox;
 
@@ -14,7 +14,7 @@
 
 /** An array of check boxes in this group.
  */
-@property (nonatomic, strong, nonnull, readonly) NSArray<BEMCheckBox *> *checkBoxes;
+@property (nonatomic, strong, nonnull, readonly) NSOrderedSet<BEMCheckBox *> *checkBoxes;
 
 /** The currently selected check box. Only can be nil if mustHaveSelection is NO. Setting this value will cause the other check boxes to deselect automatically.
  */

--- a/Classes/BEMCheckBoxGroup.m
+++ b/Classes/BEMCheckBoxGroup.m
@@ -46,7 +46,7 @@
 }
 
 - (void)addCheckBoxToGroup:(nonnull BEMCheckBox *)checkBox {
-    if([checkBox group]){
+    if ([checkBox group]) {
         // Already has a group, remove first
         [[checkBox group] removeCheckBoxFromGroup:checkBox];
     }
@@ -57,7 +57,7 @@
 }
 
 - (void)removeCheckBoxFromGroup:(nonnull BEMCheckBox *)checkBox {
-    if(![self.checkBoxes containsObject:checkBox]){
+    if (![self.checkBoxes containsObject:checkBox]) {
         // Not in this group
         return;
     }
@@ -81,11 +81,11 @@
 }
 
 - (void)setSelectedCheckBox:(BEMCheckBox *)selectedCheckBox {
-    if(selectedCheckBox){
-        for (BEMCheckBox *b in self.checkBoxes) {
-            BOOL shouldBeOn = (b == selectedCheckBox);
-            if([b on] != shouldBeOn){
-                [b _setOn:shouldBeOn animated:YES notifyGroup:NO];
+    if (selectedCheckBox) {
+        for (BEMCheckBox *checkBox in self.checkBoxes) {
+            BOOL shouldBeOn = (checkBox == selectedCheckBox);
+            if([checkBox on] != shouldBeOn){
+                [checkBox _setOn:shouldBeOn animated:YES notifyGroup:NO];
             }
         }
     } else {
@@ -104,11 +104,11 @@
     }
 }
 
-- (void)setMustHaveSelection:(BOOL)mustHaveSelection{
+- (void)setMustHaveSelection:(BOOL)mustHaveSelection {
     _mustHaveSelection = mustHaveSelection;
     
     // If it must have a selection and we currently don't, select the first box
-    if(mustHaveSelection && !self.selectedCheckBox){
+    if (mustHaveSelection && !self.selectedCheckBox) {
         [self setSelectedCheckBox:[self.checkBoxes firstObject]];
     }
 }
@@ -116,7 +116,7 @@
 #pragma mark Private methods called by BEMCheckBox
 
 - (void)_checkBoxSelectionChanged:(BEMCheckBox *)checkBox {
-    if([checkBox on]){
+    if ([checkBox on]) {
         // Change selected checkbox to this one
         [self setSelectedCheckBox:checkBox];
     } else if(checkBox == self.selectedCheckBox) {

--- a/Classes/BEMCheckBoxGroup.m
+++ b/Classes/BEMCheckBoxGroup.m
@@ -1,0 +1,128 @@
+//
+//  BEMCheckBoxGroup.m
+//  CheckBox
+//
+//  Created by Cory Imdieke on 10/17/16.
+//  Copyright © 2016 Boris Emorine. All rights reserved.
+//
+
+#import "BEMCheckBoxGroup.h"
+#import "BEMCheckBox.h"
+
+@interface BEMCheckBoxGroup ()
+
+@property (nonatomic, strong, nonnull) NSArray<BEMCheckBox *> *checkBoxes;
+
+@end
+
+/** Defines private methods that we can call on the check box.
+ */
+@interface BEMCheckBox ()
+
+@property (weak, nonatomic, nullable) BEMCheckBoxGroup *group;
+
+- (void)_setOn:(BOOL)on animated:(BOOL)animated notifyGroup:(BOOL)notifyGroup;
+
+@end
+
+@implementation BEMCheckBoxGroup
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        _mustHaveSelection = NO;
+        _checkBoxes = @[];
+    }
+    return self;
+}
+
++ (nonnull instancetype)groupWithCheckBoxes:(nullable NSArray<BEMCheckBox *> *)checkBoxes {
+    BEMCheckBoxGroup *group = [[BEMCheckBoxGroup alloc] init];
+    for (BEMCheckBox *checkbox in checkBoxes) {
+        [group addCheckBoxToGroup:checkbox];
+    }
+    
+    return group;
+}
+
+- (void)addCheckBoxToGroup:(nonnull BEMCheckBox *)checkBox {
+    if([checkBox group]){
+        // Already has a group, remove first
+        [[checkBox group] removeCheckBoxFromGroup:checkBox];
+    }
+    
+    [checkBox _setOn:NO animated:NO notifyGroup:NO];
+    [checkBox setGroup:self];
+    self.checkBoxes = [self.checkBoxes arrayByAddingObject:checkBox];
+}
+
+- (void)removeCheckBoxFromGroup:(nonnull BEMCheckBox *)checkBox {
+    if(![self.checkBoxes containsObject:checkBox]){
+        // Not in this group
+        return;
+    }
+    
+    [checkBox setGroup:nil];
+    NSMutableArray *mutableBoxes = [self.checkBoxes mutableCopy];
+    [mutableBoxes removeObject:checkBox];
+    self.checkBoxes = [NSArray arrayWithArray:mutableBoxes];
+}
+
+- (BEMCheckBox *)selectedCheckBox {
+    BEMCheckBox *checkbox = nil;
+    for (BEMCheckBox *b in self.checkBoxes) {
+        if([b on]){
+            checkbox = b;
+            break;
+        }
+    }
+    
+    return checkbox;
+}
+
+- (void)setSelectedCheckBox:(BEMCheckBox *)selectedCheckBox {
+    if(selectedCheckBox){
+        for (BEMCheckBox *b in self.checkBoxes) {
+            BOOL shouldBeOn = (b == selectedCheckBox);
+            if([b on] != shouldBeOn){
+                [b _setOn:shouldBeOn animated:YES notifyGroup:NO];
+            }
+        }
+    } else {
+        // Selection is nil
+        if(self.mustHaveSelection && [self.checkBoxes count] > 0){
+            // We must have a selected checkbox, so re-call this method with the first checkbox
+            [self setSelectedCheckBox:[self.checkBoxes firstObject]];
+        } else {
+            for (BEMCheckBox *b in self.checkBoxes) {
+                BOOL shouldBeOn = NO;
+                if([b on] != shouldBeOn){
+                    [b _setOn:shouldBeOn animated:YES notifyGroup:NO];
+                }
+            }
+        }
+    }
+}
+
+- (void)setMustHaveSelection:(BOOL)mustHaveSelection{
+    _mustHaveSelection = mustHaveSelection;
+    
+    // If it must have a selection and we currently don't, select the first box
+    if(mustHaveSelection && !self.selectedCheckBox){
+        [self setSelectedCheckBox:[self.checkBoxes firstObject]];
+    }
+}
+
+#pragma mark Private methods called by BEMCheckBox
+
+- (void)_checkBoxSelectionChanged:(BEMCheckBox *)checkBox {
+    if([checkBox on]){
+        // Change selected checkbox to this one
+        [self setSelectedCheckBox:checkBox];
+    } else if(checkBox == self.selectedCheckBox) {
+        // Selected checkbox was this one, clear it
+        [self setSelectedCheckBox:nil];
+    }
+}
+
+@end

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@
 * [**Documentation**](#documentation)
   * [Enabling / Disabling the Checkbox](#enabling--disabling-the-checkbox) 
   * [Reloading](#reloading)
+  * [Group / Radio Button Functionality](#group--radio-button-functionality)
   * [Delegate] (#delegate)
   * [Customization](#customization)
-  * [Group / Radio Button Functionality](#group--radio-button-functionality)
 
 ## Project Details
 Learn more about the **BEMCheckBox** project, licensing, support etc.
@@ -117,6 +117,25 @@ Example usage:
 [self.myCheckBox reload]
 ```
 
+### Group / Radio Button Functionality
+**BEMCheckBox**es can be easily grouped together to form radio button functionality. This will automatically manage the state of each checkbox in the group so that only one is selected at a time, and can optionally require that the group has a selection at all times.
+
+```objective-c
+self.group = [BEMCheckBoxGroup groupWithCheckBoxes:@[self.checkBox1, self.checkBox2, self.checkBox3]];
+self.group.selectedCheckBox = self.checkBox2; // Optionally set which checkbox is pre-selected
+self.group.mustHaveSelection = YES; // Define if the group must always have a selection
+```
+
+To see which checkbox is selected in that group, just ask for it:
+```objective-c
+BEMCheckBox *selection = self.group.selectedCheckBox;
+```
+
+To manually update the selection for a group, just set it:
+```objective-c
+self.group.selectedCheckBox = self.checkBox1;
+```
+
 ### Delegate
 **BEMCheckBox** uses a delegate to receive check box events. The delegate object must conform to the `BEMCheckBoxDelegate` protocol, which is composed of two optional methods:
 
@@ -185,23 +204,3 @@ The possible values for `onAnimationType` and `offAnimationType`.
 
 - `BEMAnimationTypeFade`
 <p align="left"><img src="http://s24.postimg.org/3n1rre1cx/BEMAnimation_Type_Fade.gif"/></p>
-
-### Group / Radio Button Functionality
-**BEMCheckBox**es can be easily grouped together to form radio button functionality. This will automatically manage the state of each checkbox in the group so that only one is selected at a time, and can optionally require that the group has a selection at all times.
-
-Example group creation:
-```objective-c
-self.group = [BEMCheckBoxGroup groupWithCheckBoxes:@[self.checkBox1, self.checkBox2, self.checkBox3]];
-self.group.selectedCheckBox = self.checkBox2; // Optionally set which checkbox is pre-selected
-self.group.mustHaveSelection = YES; // Define if the group must always have a selection
-```
-
-To see which checkbox is selected in that group, just ask for it:
-```objective-c
-BEMCheckBox *selection = self.group.selectedCheckBox;
-```
-
-To manually update the selection for a group, just set it:
-```objective-c
-self.group.selectedCheckBox = self.checkBox1;
-```

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
   * [Reloading](#reloading)
   * [Delegate] (#delegate)
   * [Customization](#customization)
+  * [Group / Radio Button Functionality](#group--radio-button-functionality)
 
 ## Project Details
 Learn more about the **BEMCheckBox** project, licensing, support etc.
@@ -185,3 +186,22 @@ The possible values for `onAnimationType` and `offAnimationType`.
 - `BEMAnimationTypeFade`
 <p align="left"><img src="http://s24.postimg.org/3n1rre1cx/BEMAnimation_Type_Fade.gif"/></p>
 
+### Group / Radio Button Functionality
+**BEMCheckBox**es can be easily grouped together to form radio button functionality. This will automatically manage the state of each checkbox in the group so that only one is selected at a time, and can optionally require that the group has a selection at all times.
+
+Example group creation:
+```objective-c
+self.group = [BEMCheckBoxGroup groupWithCheckBoxes:@[self.checkBox1, self.checkBox2, self.checkBox3]];
+self.group.selectedCheckBox = self.checkBox2; // Optionally set which checkbox is pre-selected
+self.group.mustHaveSelection = YES; // Define if the group must always have a selection
+```
+
+To see which checkbox is selected in that group, just ask for it:
+```objective-c
+BEMCheckBox *selection = self.group.selectedCheckBox;
+```
+
+To manually update the selection for a group, just set it:
+```objective-c
+self.group.selectedCheckBox = self.checkBox1;
+```

--- a/Sample Project/CheckBox.xcodeproj/project.pbxproj
+++ b/Sample Project/CheckBox.xcodeproj/project.pbxproj
@@ -15,6 +15,9 @@
 		5643F13B1CDE724A0020E238 /* BEMAnimationManager.m in Sources */ = {isa = PBXBuildFile; fileRef = C3E837A91BAE3493004576D6 /* BEMAnimationManager.m */; };
 		5643F13C1CDE724A0020E238 /* BEMPathManager.h in Headers */ = {isa = PBXBuildFile; fileRef = C3E837AB1BAE35D8004576D6 /* BEMPathManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5643F13D1CDE724A0020E238 /* BEMPathManager.m in Sources */ = {isa = PBXBuildFile; fileRef = C3E837AC1BAE35D8004576D6 /* BEMPathManager.m */; };
+		984F9E0F1DB59228002F746B /* BEMCheckBoxGroup.h in Headers */ = {isa = PBXBuildFile; fileRef = 984F9E0D1DB59228002F746B /* BEMCheckBoxGroup.h */; };
+		984F9E101DB59228002F746B /* BEMCheckBoxGroup.m in Sources */ = {isa = PBXBuildFile; fileRef = 984F9E0E1DB59228002F746B /* BEMCheckBoxGroup.m */; };
+		984F9E111DB59228002F746B /* BEMCheckBoxGroup.m in Sources */ = {isa = PBXBuildFile; fileRef = 984F9E0E1DB59228002F746B /* BEMCheckBoxGroup.m */; };
 		C32537131B9231780059F394 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = C32537121B9231780059F394 /* main.m */; };
 		C32537161B9231780059F394 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = C32537151B9231780059F394 /* AppDelegate.m */; };
 		C325371C1B9231780059F394 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C325371A1B9231780059F394 /* Main.storyboard */; };
@@ -70,6 +73,8 @@
 		5643F12B1CDE722C0020E238 /* BEMCheckBox.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BEMCheckBox.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5643F12D1CDE722C0020E238 /* CheckBox.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CheckBox.h; sourceTree = "<group>"; };
 		5643F12F1CDE722C0020E238 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		984F9E0D1DB59228002F746B /* BEMCheckBoxGroup.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BEMCheckBoxGroup.h; path = ../Classes/BEMCheckBoxGroup.h; sourceTree = "<group>"; };
+		984F9E0E1DB59228002F746B /* BEMCheckBoxGroup.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = BEMCheckBoxGroup.m; path = ../Classes/BEMCheckBoxGroup.m; sourceTree = "<group>"; };
 		C325370D1B9231780059F394 /* CheckBox.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CheckBox.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C32537111B9231780059F394 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C32537121B9231780059F394 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
@@ -219,6 +224,8 @@
 				C3E837A91BAE3493004576D6 /* BEMAnimationManager.m */,
 				C3E837AB1BAE35D8004576D6 /* BEMPathManager.h */,
 				C3E837AC1BAE35D8004576D6 /* BEMPathManager.m */,
+				984F9E0D1DB59228002F746B /* BEMCheckBoxGroup.h */,
+				984F9E0E1DB59228002F746B /* BEMCheckBoxGroup.m */,
 			);
 			name = Classes;
 			sourceTree = "<group>";
@@ -239,6 +246,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				984F9E0F1DB59228002F746B /* BEMCheckBoxGroup.h in Headers */,
 				5643F1381CDE724A0020E238 /* BEMCheckBox.h in Headers */,
 				5643F13C1CDE724A0020E238 /* BEMPathManager.h in Headers */,
 				5643F13A1CDE724A0020E238 /* BEMAnimationManager.h in Headers */,
@@ -408,6 +416,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5643F1391CDE724A0020E238 /* BEMCheckBox.m in Sources */,
+				984F9E111DB59228002F746B /* BEMCheckBoxGroup.m in Sources */,
 				5643F13D1CDE724A0020E238 /* BEMPathManager.m in Sources */,
 				5643F13B1CDE724A0020E238 /* BEMAnimationManager.m in Sources */,
 			);
@@ -420,6 +429,7 @@
 				C39F1AB71BAFEAA400E8A023 /* BEMMainViewController.m in Sources */,
 				C3DFB9BD1BBD0E2800D2F8B4 /* BEMAnimationsTableViewController.m in Sources */,
 				C32537161B9231780059F394 /* AppDelegate.m in Sources */,
+				984F9E101DB59228002F746B /* BEMCheckBoxGroup.m in Sources */,
 				C32537131B9231780059F394 /* main.m in Sources */,
 				C3E594901BC220C7005EA38B /* BEMCurrentSetupTableViewController.m in Sources */,
 			);


### PR DESCRIPTION
I'm not sure what you think about this, but I've added some functionality that enables the creation of radio button groups. This allows for the definition of a group of check boxes where only one can be selected at a time, and it can optionally disallow no selections in that group.

If you like the idea I can add some documentation to the README file before merging.

Here's basics on how it works.

Say we have 3 checkboxes that we want to group:
```objc
@property (strong, nonatomic) IBOutlet BEMCheckBox *checkBox1;
@property (strong, nonatomic) IBOutlet BEMCheckBox *checkBox2;
@property (strong, nonatomic) IBOutlet BEMCheckBox *checkBox3;
```

We create a group for the checkboxes:
```objc
@property (strong, nonatomic) BEMCheckBoxGroup *group;
```

Then we add the checkboxes to the group:
```objc
- (void)viewDidLoad {
    [super viewDidLoad];
    
    self.group = [BEMCheckBoxGroup groupWithCheckBoxes:@[self.checkBox1, self.checkBox2, self.checkBox3]];
    self.group.selectedCheckBox = self.checkBox2; // Optionally set which checkbox is pre-selected
    self.group.mustHaveSelection = YES; // Define if there can be no checkboxes selected
}
```

That's it. You can find out which box is currently selected in the group by asking for it:
```objc
BEMCheckBox *selection = self.group.selectedCheckBox;
```

We can also manually change which box is selected at any time, which will automatically update the other group's box states as well:
```objc
self.group.selectedCheckBox = self.checkBox1; // Boxes 2 and 3 will be deselected if one is selected
```

Of course, the target action and delegate callbacks will all get sent as expected.

Let me know any feedback you have. Hopefully this will be useful.