### PR TITLE
Fix bug #54 - Group CheckBoxes

### DIFF
--- a/Classes/BEMCheckBox.h
+++ b/Classes/BEMCheckBox.h
@@ -116,7 +116,7 @@ typedef NS_ENUM(NSInteger, BEMAnimationType) {
 
 /** The group this box is associated with.
  */
-@property (weak, nonatomic, nullable, readonly) BEMCheckBoxGroup *group;
+@property (strong, nonatomic, nullable, readonly) BEMCheckBoxGroup *group;
 
 /** The type of box.
  * @see BEMBoxType. 

--- a/Classes/BEMCheckBox.m
+++ b/Classes/BEMCheckBox.m
@@ -35,7 +35,7 @@
 
 /** The group this box is associated with.
  */
-@property (weak, nonatomic, nullable) BEMCheckBoxGroup *group;
+@property (strong, nonatomic, nullable) BEMCheckBoxGroup *group;
 
 @end
 

--- a/Classes/BEMCheckBoxGroup.h
+++ b/Classes/BEMCheckBoxGroup.h
@@ -14,7 +14,7 @@
 
 /** An array of check boxes in this group.
  */
-@property (nonatomic, strong, nonnull, readonly) NSOrderedSet<BEMCheckBox *> *checkBoxes;
+@property (nonatomic, strong, nonnull, readonly) NSHashTable *checkBoxes;
 
 /** The currently selected check box. Only can be nil if mustHaveSelection is NO. Setting this value will cause the other check boxes to deselect automatically.
  */

--- a/Classes/BEMCheckBoxGroup.m
+++ b/Classes/BEMCheckBoxGroup.m
@@ -11,7 +11,7 @@
 
 @interface BEMCheckBoxGroup ()
 
-@property (nonatomic, strong, nonnull) NSOrderedSet<BEMCheckBox *> *checkBoxes;
+@property (nonatomic, strong, nonnull) NSHashTable *checkBoxes;
 
 @end
 
@@ -19,7 +19,7 @@
  */
 @interface BEMCheckBox ()
 
-@property (weak, nonatomic, nullable) BEMCheckBoxGroup *group;
+@property (strong, nonatomic, nullable) BEMCheckBoxGroup *group;
 
 - (void)_setOn:(BOOL)on animated:(BOOL)animated notifyGroup:(BOOL)notifyGroup;
 
@@ -31,7 +31,7 @@
     self = [super init];
     if (self) {
         _mustHaveSelection = NO;
-        _checkBoxes = [NSOrderedSet orderedSet];
+        _checkBoxes = [NSHashTable hashTableWithOptions:NSPointerFunctionsWeakMemory];
     }
     return self;
 }
@@ -52,9 +52,8 @@
     
     [checkBox _setOn:NO animated:NO notifyGroup:NO];
     checkBox.group = self;
-    NSMutableOrderedSet *mutableBoxes = [self.checkBoxes mutableCopy];
-    [mutableBoxes addObject:checkBox];
-    self.checkBoxes = [NSOrderedSet orderedSetWithOrderedSet:mutableBoxes];
+
+    [self.checkBoxes addObject:checkBox];
 }
 
 - (void)removeCheckBoxFromGroup:(nonnull BEMCheckBox *)checkBox {
@@ -64,9 +63,7 @@
     }
     
     checkBox.group = nil;
-    NSMutableOrderedSet *mutableBoxes = [self.checkBoxes mutableCopy];
-    [mutableBoxes removeObject:checkBox];
-    self.checkBoxes = [NSOrderedSet orderedSetWithOrderedSet:mutableBoxes];
+    [self.checkBoxes removeObject:checkBox];
 }
 
 #pragma mark Getters
@@ -97,7 +94,7 @@
         // Selection is nil
         if(self.mustHaveSelection && [self.checkBoxes count] > 0){
             // We must have a selected checkbox, so re-call this method with the first checkbox
-            self.selectedCheckBox = [self.checkBoxes firstObject];
+            self.selectedCheckBox = [self.checkBoxes anyObject];
         } else {
             for (BEMCheckBox *checkBox in self.checkBoxes) {
                 BOOL shouldBeOn = NO;
@@ -114,7 +111,7 @@
     
     // If it must have a selection and we currently don't, select the first box
     if (mustHaveSelection && !self.selectedCheckBox) {
-        self.selectedCheckBox = [self.checkBoxes firstObject];
+        self.selectedCheckBox = [self.checkBoxes anyObject];
     }
 }
 

--- a/Sample Project/CheckBoxTests/GroupTests.m
+++ b/Sample Project/CheckBoxTests/GroupTests.m
@@ -67,10 +67,10 @@
     XCTAssertNil(group.selectedCheckBox);
     
     group.mustHaveSelection = YES;
-    XCTAssertEqual(group.selectedCheckBox, [self.checkBoxes firstObject]);
+    XCTAssertNotNil(group.selectedCheckBox);
     
     group.selectedCheckBox = nil;
-    XCTAssertEqual(group.selectedCheckBox, [self.checkBoxes firstObject]);
+    XCTAssertNotNil(group.selectedCheckBox);
 }
 
 - (void)testAddCheckBox {


### PR DESCRIPTION
@Vortec4800, could you take a look at this PR?
There seem to be a bug with groups (#54). If you don't keep a strong reference to a group somewhere, it gets deallocated even if it is used by checkboxes.  
I changed things around: now checkboxes keep a strong reference to their group, and the group stores the checkboxes weakly thanks to NSHashTable.