### PR TITLE
Update Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "BEMCheckBox",
     platforms: [
-       .iOS(.v8)
+       .iOS(.v9)
     ],
     products: [
         .library(name: "BEMCheckBox", targets: ["BEMCheckBox"])


### PR DESCRIPTION
"Platforms" in Package.swift should be updated from iOS v8 to iOS v9 to reflect the minimum supported deployment target version and thus silence a warning when using Swift Package Manager.